### PR TITLE
Changed overdue recurring task functionality.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ target/
 # VSCODE
 .json
 .vscode
+test.ipynb

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ Todoist allows the asterisk symbol `* ` to be used to ensure tasks can't be chec
 
 Simply add `** ` or `!* ` in front of a project, section, or top item, to automatically turn all the items that it includes into respectively headers or checkable tasks.
 
+# 5. Change overdue recurring task completion behavior.
+
+You have a task that you need to complete every day. You can't do it one day, and complete it the following morning. You still want to complete the task again later that day, but when you check off the task, Todoist sets the next occurence as the following day!
+
+By enabling this mode, overdue daily recurring tasks' next occurence will be set to today instead of tomorrow. This only applies to tasks that can be moved back. For example if you have a recurring task daily at 7am, and it is 10am, the task will not move back to today.
+
 # Executing Autodoist
 
 You can run Autodoist from any system that supports Python.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This program adds four major functionalities to Todoist to help automate your wo
 2) Enable regeneration of sub-tasks in lists with a recurring date. Multiple modes possile.
 3) Postpone the end-of-day time to after midnight to finish your daily recurring tasks
 4) Make multiple items (un)checkable at the same time
+5) Overdue daily recurring tasks next occurence can be made to be scheduled for today instead of tomorrow when completed.
 
 If this tool helped you out, I would really appreciate your support by providing me with some coffee!
 
@@ -129,6 +130,10 @@ If you want to enable regeneration of sub-tasks in recurring lists, run with the
 If you want to enable an alternative end-of-day, run with the `-e` argument and a number from 1 to 24 to specify which hour:
 
     python autodoist.py -a <API Key> -e <NUMBER>
+    
+If you want to enable alternative overdue recurring task functionality, run with the `-o` argument followed by a mode number for the overall functionality (0: behavior off, 1: behavior on):
+
+    python autodoist.py -a <API Key> -o <NUMBER>
     
 These modes can be run individually, or combined with each other.
 

--- a/autodoist.py
+++ b/autodoist.py
@@ -642,7 +642,6 @@ def overdue_recurring_completed(api):
                     else:
                         new_date = str(dt_new_date.strftime('%Y-%m-%d')) + 'T' + str(dt_new_date.strftime('%H:%M:%S'))
 
-                    print(f"|{new_date}|")
                     due = task['due']
                     print(due)
                     due['date'] = str(new_date)

--- a/autodoist.py
+++ b/autodoist.py
@@ -143,10 +143,10 @@ def initialise(args):
 
     logging.info("You are running with the following functionalities:\n\n   Next action labelling mode: {}\n   Regenerate sub-tasks mode: {}\n   Shifted end-of-day mode: {}\n".format(*modes))
 
-    if m_num == 0:
-        logging.info(
-            "\n No functionality has been enabled. Please see --help for the available options.\n")
-        exit(0)
+    # if m_num == 0:
+    #     logging.info(
+    #         "\n No functionality has been enabled. Please see --help for the available options.\n")
+    #     exit(0)
 
     # Run the initial sync
     logging.debug('Connecting to the Todoist API')
@@ -642,11 +642,12 @@ def overdue_recurring_completed(api):
                     else:
                         new_date = str(dt_new_date.strftime('%Y-%m-%d')) + 'T' + str(dt_new_date.strftime('%H:%M:%S'))
 
-                    print(new_date)
+                    print(f"|{new_date}|")
                     due = task['due']
-                    due['date'] = new_date
-                    api.items.get_by_id(event['object_id']).update(due=new_date)
-                    api.commit()
+                    print(due)
+                    due['date'] = str(new_date)
+                    task.update(due=due)
+                    # api.commit()
             curr += 1
 
     # set the new most recent event

--- a/autodoist.py
+++ b/autodoist.py
@@ -643,7 +643,6 @@ def overdue_recurring_completed(api):
                         new_date = str(dt_new_date.strftime('%Y-%m-%d')) + 'T' + str(dt_new_date.strftime('%H:%M:%S'))
 
                     due = task['due']
-                    print(due)
                     due['date'] = str(new_date)
                     task.update(due=due)
             curr += 1

--- a/autodoist.py
+++ b/autodoist.py
@@ -556,6 +556,47 @@ def run_recurring_lists_logic(args, api, item, child_items, child_items_all, reg
             #               item['content'])
             pass
 
+# When a daily recurring task that is overdue is completed, the next occurence
+# of the task is set to tomorrow. This code will change it to one day prior
+# if the time has not already elapsed
+most_recent_event = None
+
+def overdue_recurring_completed(args, api, label_id, regen_labels_id):
+    # get current list of events
+    events = api.activity.get()['events']
+
+    curr = 0
+    if most_recent_event is None:
+        # if there are no events
+        if events is "" or events is None:
+            return;
+        # else,
+        most_recent_event = events[curr]['event_date']
+    # if an event has occured since the last function call
+    else:
+        # look through the events that have occured since
+        while events[curr]['event_date'] != most_recent_event:
+            event = events[curr]
+
+            # if a recurring task has been completed
+            if event['event_type'] == 'completed' \
+                and api.items.get_by_id(event['object_id'])['due']['is_recurring']:
+                
+                # get the previous date of that event (somehow)
+
+                # if previous date was before today and new date is tomorrow
+                    # if new date - one day is after current time, subtract one
+                    # day from the date on the recurring task
+                    new_date = 'something'
+                    api.item_update(id=event['object_id'], due=new_date)
+
+
+            curr += 1
+
+    # set the new most recent event
+    most_recent_event = events[0]['event_date']
+    
+
 # Contains all main autodoist functionalities
 
 
@@ -564,6 +605,8 @@ def autodoist_magic(args, api, label_id, regen_labels_id):
     # Preallocate dictionaries
     overview_item_ids = {}
     overview_item_labels = {}
+
+    # call overdue
 
     for project in api.projects.all():
 


### PR DESCRIPTION
I added a mode that changes the way that overdue task functionality works. If you complete an overdue daily recurring task, its next occurrence will be set to today instead of tomorrow. This only holds if the new time has not elapsed yet. For example, a task recurring daily at 7 am will not move back if completed at 10 am.

I also updated the readme to reflect this.