### PR TITLE
Improve section task handling

### DIFF
--- a/autodoist.py
+++ b/autodoist.py
@@ -623,13 +623,12 @@ def autodoist_magic(args, api, label_id, regen_labels_id):
 
                 # If a type has changed, clean label for good measure
                 if label_id is not None:
-                    if project_type_changed == 1 or section_type_changed == 1:
-                        # Remove labels
-                        [remove_label(item, label_id, overview_item_ids,
-                                      overview_item_labels) for item in items]
-                        # Remove parent types
-                        for item in items:
-                            item['parent_type'] = None
+                    # Remove labels
+                    [remove_label(item, label_id, overview_item_ids,
+                                  overview_item_labels) for item in items]
+                    # Remove parent types
+                    for item in items:
+                        item['parent_type'] = None
 
                 # For all items in this section
                 for item in items:


### PR DESCRIPTION
Currently it is quite easy to have two tasts in the same
section with a next label, so let's remove the next label
from all cards and recalculate whether the task should
have the next label on every run.

Note this will not increate the API usage, as only the
final diff will be sent to Todoist.

Signed-off-by: Christopher Obbard <chris@64studio.com>