### PR TITLE
Don't stop processing sections if task is past hide_future

### DIFF
--- a/autodoist.py
+++ b/autodoist.py
@@ -336,6 +336,7 @@ def add_label(item, label, overview_item_ids, overview_item_labels):
 # Logic to remove a label from an item
 
 
+# returns True if the label was removed; False otherwise
 def remove_label(item, label, overview_item_ids, overview_item_labels):
     if label in item['labels']:
         labels = item['labels']
@@ -347,6 +348,8 @@ def remove_label(item, label, overview_item_ids, overview_item_labels):
         except:
             overview_item_ids[str(item['id'])] = -1
         overview_item_labels[str(item['id'])] = labels
+        return True
+    return False
 
 # Ensure labels are only issued once per item
 

--- a/autodoist.py
+++ b/autodoist.py
@@ -809,9 +809,10 @@ def autodoist_magic(args, api, label_id, regen_labels_id):
                                 future_diff = (
                                     due_date - datetime.today()).days
                                 if future_diff >= args.hide_future:
-                                    remove_label(
-                                        item, label_id, overview_item_ids, overview_item_labels)
-                                    continue
+                                    if remove_label(
+                                        item, label_id, overview_item_ids, overview_item_labels):
+                                        first_found_section = False
+                                        continue
                         except:
                             # Hide-future not set, skip
                             continue


### PR DESCRIPTION
If the top task in a section has a due date past hide_future,
the tasks after it do not get a Next tag. Let's fix that.

Signed-off-by: Christopher Obbard <chris@64studio.com>