### PR TITLE
Fix error in due date when using the alternatvie end of day feature

### DIFF
--- a/autodoist.py
+++ b/autodoist.py
@@ -521,11 +521,15 @@ def run_recurring_lists_logic(args, api, item, child_items, child_items_all, reg
                                     if len(today_str[1]) == 1:
                                         today_str[1] = ''.join(
                                             ['0', today_str[1]])
+                                    if len(today_str[2]) == 1:
+                                        today_str[2] = ''.join(
+                                            ['0', today_str[2]])
 
                                     # Update due-date to today
                                     item_due = item['due']
                                     item_due['date'] = '-'.join(
                                         today_str)
+                                    logging.debug('Setting task due to: %s' % (item_due))
                                     item.update(due=item_due)
                                     # item.update(due={'date': '2020-05-29', 'is_recurring': True, 'string': 'every day'})
 


### PR DESCRIPTION
While trying to use the alternative end of day feature I stumbled over a bug that got triggered because the day of the newly commited date was invalid.

The error message from todoist was:
```
todoist.api.SyncError: ('***', {'error': 'Date is invalid', 'error_code': 480, 'error_extra': {}, 'error_tag': 'INVALID_DATE', 'http_code': 400})
```

I fixed it the same way it has already been fixed with the month.