### PR TITLE
Migrate from Sync API v9 to v1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.28.1
-todoist_api_python==2.0.2
+requests>=2.32.3,<3
+todoist_api_python==3.2.1


### PR DESCRIPTION
## Summary
Migrates the codebase from deprecated Sync API v9 to the current Sync API v1 endpoint, and updates todoist_api_python from 2.0.2 to 3.2.1 to support API v3 changes.

This should fix #49 .

## Changes
- Update Sync API endpoint from `v9/sync` to `v1/sync`
- Handle pagination for `get_labels()`, `get_projects()`, `get_sections()`, `get_tasks()` in API v3
- Fix Section model initialization for API v3 compatibility
- Add proper error handling and logging for sync API failures
- Fix regex patterns using raw string literals
- Update task sorting to handle string IDs in API v3
- Update dependencies:
  - `todoist_api_python`: 2.0.2 → 3.2.1
  - `requests`: 2.28.1 → >=2.32.3,<3

## Breaking Change Context
The Todoist Sync API v9 endpoint has been deprecated/broken, causing the application to fail. This migration is necessary for continued functionality.

## ⚠️ Migration Requirements

**IMPORTANT:** After updating to this version, users must delete their existing `metadata.sqlite` database file before running the application. The Todoist API v3 changed task/project/section IDs from integers to strings, making the existing database incompatible.

```bash
# Delete the database file
rm metadata.sqlite

# Then run autodoist normally
python autodoist.py -a <API_KEY>
```

The database will be automatically recreated with the correct schema on the first run.

## Testing

Tested with existing Todoist projects and confirmed:
- Label verification works with pagination
- Project/section/task retrieval works with pagination
- Sync operations succeed with v1 endpoint
- Section handling works with updated model initialization
- Database recreation works correctly with string IDs